### PR TITLE
Critical patch for runtime 1.8.0 ovr_Initialize returns an error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>[4, 5)</version>
+      <version>4.2.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/com/oculusvr/capi/Hmd.java
+++ b/src/main/java/com/oculusvr/capi/Hmd.java
@@ -30,8 +30,13 @@ public class Hmd extends PointerType {
   }
 
   public static void initialize() {
-    if (0 > OvrLibrary.INSTANCE.ovr_Initialize(Pointer.NULL)) {
-      throw new IllegalStateException("Unable to initialize Oculus SDK");
+    InitParams initParams = new InitParams();
+    initParams.Flags = OvrLibrary.ovrInitFlags.ovrInit_RequestVersion;
+    initParams.RequestedMinorVersion = 3;
+    
+    final int result = OvrLibrary.INSTANCE.ovr_Initialize(initParams);
+    if (0 > result) {
+      throw new IllegalStateException("Unable to initialize Oculus SDK: "  + result);
     }
   }
 

--- a/src/main/java/com/oculusvr/capi/InitParams.java
+++ b/src/main/java/com/oculusvr/capi/InitParams.java
@@ -1,0 +1,50 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.oculusvr.capi;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ *
+ * @author hcram
+ */
+public class InitParams extends Structure {
+
+    /// Flags from ovrInitFlags to override default behavior.
+    /// Use 0 for the defaults.
+    public short        Flags;
+
+    /// Requests a specific minor version of the LibOVR runtime.
+    /// Flags must include ovrInit_RequestVersion or this will be ignored and OVR_MINOR_VERSION 
+    /// will be used. If you are directly calling the LibOVRRT version of ovr_Initialize
+    /// in the LibOVRRT DLL then this must be valid and include ovrInit_RequestVersion.
+    public short        RequestedMinorVersion;
+
+    /// User-supplied log callback function, which may be called at any time
+    /// asynchronously from multiple threads until ovr_Shutdown completes.
+    /// Use NULL to specify no log callback.
+    public Pointer LogCallback;
+
+    /// User-supplied data which is passed as-is to LogCallback. Typically this
+    /// is used to store an application-specific pointer which is read in the
+    /// callback function.
+    public Pointer      UserData;
+
+    /// Relative number of milliseconds to wait for a connection to the server
+    /// before failing. Use 0 for the default timeout.
+    public short        ConnectionTimeoutMS;
+
+    public byte[] padding1 = new byte[4]; ///< \internal  
+    
+  @Override
+  protected List getFieldOrder() {
+    return Arrays.asList("Flags", "RequestedMinorVersion", "LogCallback", "UserData", "ConnectionTimeoutMS", "padding1");  
+  }
+  
+}


### PR DESCRIPTION
This patch solves this known issue in documentation:

If you bypass the shim and communicate with the DLL directly, without specifying a version to ovr_Initialize, the DLL has no way of knowing the SDK version with which the application was built. This can result in unpredictable or erratic behavior which might cause the application to crash.

All Runtime versions prior 1.8 worked without this, but 1.8 will refuse to initialize without specifying the runtime version we aren requesting
